### PR TITLE
Bump version to v0.6.1

### DIFF
--- a/Framework/Sources/Info.plist
+++ b/Framework/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/SpreadsheetView.podspec
+++ b/SpreadsheetView.podspec
@@ -1,9 +1,20 @@
 Pod::Spec.new do |s|
   s.name             = 'SpreadsheetView'
-  s.version          = '0.6.0'
+  s.version          = '0.6.1'
   s.summary          = 'Full configurable spreadsheet view user interfaces for iOS applications.'
   s.description      = <<-DESC
-                         Full configurable spreadsheet view user interfaces for iOS applications. With this framework, you can easily create complex layouts like schedule, gantt chart or timetable as if you are using Excel.
+                         Full configurable spreadsheet view user interfaces for iOS applications. With this framework, 
+                         you can easily create complex layouts like schedule, gantt chart or timetable as if you are using Excel.
+
+                         Features
+                         - Fixed column and row headers
+                         - Merge cells
+                         - Circular infinite scrolling automatically
+                         - Customize grids and borders for each cell
+                         - Customize inter cell spacing vertically and horizontally
+                         - Fast scrolling, memory efficient
+                         - `UICollectionView` like API
+                         - Well unit tested
                        DESC
   s.homepage         = 'https://github.com/kishikawakatsumi/SpreadsheetView'
   s.screenshots      = 'https://raw.githubusercontent.com/kishikawakatsumi/SpreadsheetView/master/Resources/GanttChart.png', 'https://raw.githubusercontent.com/kishikawakatsumi/SpreadsheetView/master/Resources/Timetable.png', 'https://raw.githubusercontent.com/kishikawakatsumi/SpreadsheetView/master/Resources/DailySchedule_portrait.png'


### PR DESCRIPTION
- Fix `scrollToItem(indexPath:scrollPosition:animated:)` generates incorrect results when specified index path for merged cells