### PR TITLE
Rename `Grids`/`grids` to `Gridlines`/`gridlines`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ##### Breaking
 
+* Rename `Grids`/`Cell.grids` to `Gridlines`/`Cell.gridlines`. Old type and property are now deprecated.
+  They will be removed in future version.   
+  [#13](https://github.com/kishikawakatsumi/SpreadsheetView/pull/13)
+
+##### Enhancements
+
+* None.
+
+##### Bug Fixes
+
+* None.
+
+## 0.6.2 Release notes (2017-05-16)
+
+##### Breaking
+
 * None.
 
 ##### Enhancements

--- a/Examples/GanttChart/Sources/ViewController.swift
+++ b/Examples/GanttChart/Sources/ViewController.swift
@@ -166,51 +166,51 @@ class ViewController: UIViewController, SpreadsheetViewDataSource, SpreadsheetVi
         case (0, 0):
             let cell = spreadsheetView.dequeueReusableCell(withReuseIdentifier: String(describing: HeaderCell.self), for: indexPath) as! HeaderCell
             cell.label.text = "Task"
-            cell.grids.left = .none
-            cell.grids.right = .none
+            cell.gridlines.left = .none
+            cell.gridlines.right = .none
             return cell
         case (1, 0):
             let cell = spreadsheetView.dequeueReusableCell(withReuseIdentifier: String(describing: HeaderCell.self), for: indexPath) as! HeaderCell
             cell.label.text = "Start"
-            cell.grids.left = .none
-            cell.grids.right = .none
+            cell.gridlines.left = .none
+            cell.gridlines.right = .none
             return cell
         case (2, 0):
             let cell = spreadsheetView.dequeueReusableCell(withReuseIdentifier: String(describing: HeaderCell.self), for: indexPath) as! HeaderCell
             cell.label.text = "Duration"
             cell.label.textColor = .gray
-            cell.grids.left = .none
-            cell.grids.right = .default
+            cell.gridlines.left = .none
+            cell.gridlines.right = .default
             return cell
         case (3..<(3 + 7 * weeks.count), 0):
             let cell = spreadsheetView.dequeueReusableCell(withReuseIdentifier: String(describing: HeaderCell.self), for: indexPath) as! HeaderCell
             cell.label.text = weeks[(indexPath.column - 3) / 7]
-            cell.grids.left = .default
-            cell.grids.right = .default
+            cell.gridlines.left = .default
+            cell.gridlines.right = .default
             return cell
         case (3..<(3 + 7 * weeks.count), 1):
             let cell = spreadsheetView.dequeueReusableCell(withReuseIdentifier: String(describing: HeaderCell.self), for: indexPath) as! HeaderCell
             cell.label.text = String(format: "%02d Apr", indexPath.column - 2)
-            cell.grids.left = .default
-            cell.grids.right = .default
+            cell.gridlines.left = .default
+            cell.gridlines.right = .default
             return cell
         case (0, 2..<(2 + tasks.count)):
             let cell = spreadsheetView.dequeueReusableCell(withReuseIdentifier: String(describing: TaskCell.self), for: indexPath) as! TaskCell
             cell.label.text = tasks[indexPath.row - 2][0]
-            cell.grids.left = .none
-            cell.grids.right = .none
+            cell.gridlines.left = .none
+            cell.gridlines.right = .none
             return cell
         case (1, 2..<(2 + tasks.count)):
             let cell = spreadsheetView.dequeueReusableCell(withReuseIdentifier: String(describing: TextCell.self), for: indexPath) as! TextCell
             cell.label.text = String(format: "April %02d", Int(tasks[indexPath.row - 2][1])!)
-            cell.grids.left = .none
-            cell.grids.right = .none
+            cell.gridlines.left = .none
+            cell.gridlines.right = .none
             return cell
         case (2, 2..<(2 + tasks.count)):
             let cell = spreadsheetView.dequeueReusableCell(withReuseIdentifier: String(describing: TextCell.self), for: indexPath) as! TextCell
             cell.label.text = tasks[indexPath.row - 2][2]
-            cell.grids.left = .none
-            cell.grids.right = .none
+            cell.gridlines.left = .none
+            cell.gridlines.right = .none
             return cell
         case (3..<(3 + 7 * weeks.count), 2..<(2 + tasks.count)):
             let cell = spreadsheetView.dequeueReusableCell(withReuseIdentifier: String(describing: ChartBarCell.self), for: indexPath) as! ChartBarCell

--- a/Examples/Timetable/Sources/ViewController.swift
+++ b/Examples/Timetable/Sources/ViewController.swift
@@ -121,14 +121,14 @@ class ViewController: UIViewController, SpreadsheetViewDataSource, SpreadsheetVi
         if indexPath.column == 0 && indexPath.row > 0 {
             let cell = spreadsheetView.dequeueReusableCell(withReuseIdentifier: String(describing: HourCell.self), for: indexPath) as! HourCell
             cell.label.text = hourFormatter.string(from: twelveHourFormatter.date(from: "\((indexPath.row - 1) / 60 % 24)")!)
-            cell.grids.top = .solid(width: 1, color: .white)
-            cell.grids.bottom = .solid(width: 1, color: .white)
+            cell.gridlines.top = .solid(width: 1, color: .white)
+            cell.gridlines.bottom = .solid(width: 1, color: .white)
             return cell
         }
         if indexPath.column > 0 && indexPath.row == 0 {
             let cell = spreadsheetView.dequeueReusableCell(withReuseIdentifier: String(describing: ChannelCell.self), for: indexPath) as! ChannelCell
             cell.label.text = channels[indexPath.column - 1]
-            cell.grids = .all(.solid(width: 1, color: .black))
+            cell.gridlines = .all(.solid(width: 1, color: .black))
             return cell
         }
 

--- a/Framework/Sources/Cell.swift
+++ b/Framework/Sources/Cell.swift
@@ -54,7 +54,16 @@ open class Cell: UIView {
         }
     }
 
-    public var grids = Grids(top: .default, bottom: .default, left: .default, right: .default)
+    public var gridlines = Gridlines(top: .default, bottom: .default, left: .default, right: .default)
+    @available(*, deprecated: 0.6.3, renamed: "gridlines")
+    public var grids: Grids {
+        get {
+            return gridlines
+        }
+        set {
+            gridlines = grids
+        }
+    }
     public var borders = Borders(top: .none, bottom: .none, left: .none, right: .none) {
         didSet {
             if case .none = borders.top {} else {

--- a/Framework/Sources/Grids.swift
+++ b/Framework/Sources/Grids.swift
@@ -8,16 +8,19 @@
 
 import UIKit
 
-public struct Grids {
+public struct Gridlines {
     public var top: GridStyle
     public var bottom: GridStyle
     public var left: GridStyle
     public var right: GridStyle
 
-    public static func all(_ style: GridStyle) -> Grids {
-        return Grids(top: style, bottom: style, left: style, right: style)
+    public static func all(_ style: GridStyle) -> Gridlines {
+        return Gridlines(top: style, bottom: style, left: style, right: style)
     }
 }
+
+@available(*, deprecated: 0.6.3, renamed: "Gridlines")
+public typealias Grids = Gridlines
 
 public enum GridStyle {
     case `default`
@@ -25,7 +28,20 @@ public enum GridStyle {
     case solid(width: CGFloat, color: UIColor)
 }
 
-final class Grid: CALayer {
+extension GridStyle: Equatable {
+    public static func ==(lhs: GridStyle, rhs: GridStyle) -> Bool {
+        switch (lhs, rhs) {
+        case (.none, .none):
+            return true
+        case let (.solid(lhs), .solid(rhs)):
+            return lhs.width == rhs.width && lhs.color == rhs.color
+        default:
+            return false
+        }
+    }
+}
+
+final class Gridline: CALayer {
     var color: UIColor = .clear {
         didSet {
             backgroundColor = color.cgColor

--- a/Framework/Sources/LayoutEngine.swift
+++ b/Framework/Sources/LayoutEngine.swift
@@ -104,8 +104,8 @@ class LayoutEngine {
         }
 
         renderMergedCells()
-        renderVerticalGrids()
-        renderHorizontalGrids()
+        renderVerticalGridlines()
+        renderHorizontalGridlines()
         renderBorders()
         returnReusableResouces()
     }
@@ -263,7 +263,7 @@ class LayoutEngine {
             return
         }
 
-        let grids: Grids?
+        let gridlines: Gridlines?
         let border: (borders: Borders?, hasBorders: Bool)
 
         if !scrollView.visibleCellAddresses.contains(address) {
@@ -278,7 +278,7 @@ class LayoutEngine {
             cell.isHighlighted = highlightedIndexPaths.contains(indexPath)
             cell.isSelected = selectedIndexPaths.contains(indexPath)
 
-            grids = cell.grids
+            gridlines = cell.gridlines
             border = (cell.borders, cell.hasBorders)
 
             scrollView.insertSubview(cell, at: 0)
@@ -286,10 +286,10 @@ class LayoutEngine {
         } else {
             if let cell = scrollView.visibleCells[address] {
                 cell.frame = frame
-                grids = cell.grids
+                gridlines = cell.gridlines
                 border = (cell.borders, cell.hasBorders)
             } else {
-                grids = nil
+                gridlines = nil
                 border = (nil, false)
             }
         }
@@ -297,16 +297,16 @@ class LayoutEngine {
         if border.hasBorders {
             visibleBorderAddresses.insert(address)
         }
-        if let grids = grids {
-            layoutGrids(address: address, frame: frame, grids: grids)
+        if let gridlines = gridlines {
+            layoutGridlines(address: address, frame: frame, gridlines: gridlines)
         }
     }
 
-    private func layoutGrids(address: Address, frame: CGRect, grids: Grids) {
-        let (topWidth, topColor, topPriority) = extractGridStyle(style: grids.top)
-        let (bottomWidth, bottomColor, bottomPriority) = extractGridStyle(style: grids.bottom)
-        let (leftWidth, leftColor, leftPriority) = extractGridStyle(style: grids.left)
-        let (rightWidth, rightColor, rightPriority) = extractGridStyle(style: grids.right)
+    private func layoutGridlines(address: Address, frame: CGRect, gridlines: Gridlines) {
+        let (topWidth, topColor, topPriority) = extractGridStyle(style: gridlines.top)
+        let (bottomWidth, bottomColor, bottomPriority) = extractGridStyle(style: gridlines.bottom)
+        let (leftWidth, leftColor, leftPriority) = extractGridStyle(style: gridlines.left)
+        let (rightWidth, rightColor, rightPriority) = extractGridStyle(style: gridlines.right)
 
         if let gridLayout = horizontalGridLayouts[address] {
             if topPriority > gridLayout.priority {
@@ -348,7 +348,7 @@ class LayoutEngine {
         }
     }
 
-    private func renderHorizontalGrids() {
+    private func renderHorizontalGridlines() {
         for (address, gridLayout) in horizontalGridLayouts {
             var frame = CGRect.zero
             frame.origin = gridLayout.origin
@@ -371,9 +371,9 @@ class LayoutEngine {
                 grid.zPosition = gridLayout.priority
 
                 scrollView.layer.addSublayer(grid)
-                scrollView.visibleHorizontalGrids[address] = grid
+                scrollView.visibleHorizontalGridlines[address] = grid
             } else {
-                if let grid = scrollView.visibleHorizontalGrids[address] {
+                if let grid = scrollView.visibleHorizontalGridlines[address] {
                     grid.frame = frame
                     grid.color = gridLayout.gridColor
                     grid.zPosition = gridLayout.priority
@@ -383,7 +383,7 @@ class LayoutEngine {
         }
     }
 
-    private func renderVerticalGrids() {
+    private func renderVerticalGridlines() {
         for (address, gridLayout) in verticalGridLayouts {
             var frame = CGRect.zero
             frame.origin = gridLayout.origin
@@ -406,9 +406,9 @@ class LayoutEngine {
                 grid.zPosition = gridLayout.priority
 
                 scrollView.layer.addSublayer(grid)
-                scrollView.visibleVerticalGrids[address] = grid
+                scrollView.visibleVerticalGridlines[address] = grid
             } else {
-                if let grid = scrollView.visibleVerticalGrids[address] {
+                if let grid = scrollView.visibleVerticalGridlines[address] {
                     grid.frame = frame
                     grid.color = gridLayout.gridColor
                     grid.zPosition = gridLayout.priority
@@ -481,20 +481,20 @@ class LayoutEngine {
 
         scrollView.visibleVerticalGridAddresses.subtract(visibleVerticalGridAddresses)
         for address in scrollView.visibleVerticalGridAddresses {
-            if let grid = scrollView.visibleVerticalGrids[address] {
+            if let grid = scrollView.visibleVerticalGridlines[address] {
                 grid.removeFromSuperlayer()
-                scrollView.reusableVerticalGrids.insert(grid)
-                scrollView.visibleVerticalGrids[address] = nil
+                scrollView.reusableVerticalGridlines.insert(grid)
+                scrollView.visibleVerticalGridlines[address] = nil
             }
         }
         scrollView.visibleVerticalGridAddresses = visibleVerticalGridAddresses
 
         scrollView.visibleHorizontalGridAddresses.subtract(visibleHorizontalGridAddresses)
         for address in scrollView.visibleHorizontalGridAddresses {
-            if let grid = scrollView.visibleHorizontalGrids[address] {
+            if let grid = scrollView.visibleHorizontalGridlines[address] {
                 grid.removeFromSuperlayer()
-                scrollView.reusableHorizontalGrids.insert(grid)
-                scrollView.visibleHorizontalGrids[address] = nil
+                scrollView.reusableHorizontalGridlines.insert(grid)
+                scrollView.visibleHorizontalGridlines[address] = nil
             }
         }
         scrollView.visibleHorizontalGridAddresses = visibleHorizontalGridAddresses

--- a/Framework/Sources/ScrollView.swift
+++ b/Framework/Sources/ScrollView.swift
@@ -15,13 +15,13 @@ final class ScrollView: UIScrollView, UIGestureRecognizerDelegate {
     var visibleCells = [Address: Cell]()
     var visibleCellAddresses = Set<Address>()
 
-    var visibleVerticalGrids = [Address: Grid]()
+    var visibleVerticalGridlines = [Address: Gridline]()
     var visibleVerticalGridAddresses = Set<Address>()
-    var reusableVerticalGrids = Set<Grid>()
+    var reusableVerticalGridlines = Set<Gridline>()
 
-    var visibleHorizontalGrids = [Address: Grid]()
+    var visibleHorizontalGridlines = [Address: Gridline]()
     var visibleHorizontalGridAddresses = Set<Address>()
-    var reusableHorizontalGrids = Set<Grid>()
+    var reusableHorizontalGridlines = Set<Gridline>()
 
     var visibleBorders = [Address: Border]()
     var visibleBorderAddresses = Set<Address>()
@@ -38,20 +38,20 @@ final class ScrollView: UIScrollView, UIGestureRecognizerDelegate {
         return columnRecords.count > 0 || rowRecords.count > 0
     }
 
-    func dequeueReusableVerticalGrid() -> Grid {
-        if let grid = reusableVerticalGrids.first {
-            reusableVerticalGrids.remove(grid)
+    func dequeueReusableVerticalGrid() -> Gridline {
+        if let grid = reusableVerticalGridlines.first {
+            reusableVerticalGridlines.remove(grid)
             return grid
         }
-        return Grid()
+        return Gridline()
     }
 
-    func dequeueReusableHorizontalGrid() -> Grid {
-        if let grid = reusableHorizontalGrids.first {
-            reusableHorizontalGrids.remove(grid)
+    func dequeueReusableHorizontalGrid() -> Gridline {
+        if let grid = reusableHorizontalGridlines.first {
+            reusableHorizontalGridlines.remove(grid)
             return grid
         }
-        return Grid()
+        return Gridline()
     }
 
     func dequeueReusableBorder() -> Border {

--- a/Framework/Sources/SpreadsheetView+CirclularScrolling.swift
+++ b/Framework/Sources/SpreadsheetView+CirclularScrolling.swift
@@ -20,16 +20,16 @@ extension SpreadsheetView {
             cell.center.x += centerOffset.x
         }
 
-        for grid in rowHeaderView.visibleHorizontalGrids.values {
+        for grid in rowHeaderView.visibleHorizontalGridlines.values {
             grid.position.x += centerOffset.x
         }
-        for grid in rowHeaderView.visibleVerticalGrids.values {
+        for grid in rowHeaderView.visibleVerticalGridlines.values {
             grid.position.x += centerOffset.x
         }
-        for grid in tableView.visibleHorizontalGrids.values {
+        for grid in tableView.visibleHorizontalGridlines.values {
             grid.position.x += centerOffset.x
         }
-        for grid in tableView.visibleVerticalGrids.values {
+        for grid in tableView.visibleVerticalGridlines.values {
             grid.position.x += centerOffset.x
         }
     }
@@ -45,16 +45,16 @@ extension SpreadsheetView {
             cell.center.y += centerOffset.y
         }
 
-        for grid in columnHeaderView.visibleHorizontalGrids.values {
+        for grid in columnHeaderView.visibleHorizontalGridlines.values {
             grid.position.y += centerOffset.y
         }
-        for grid in columnHeaderView.visibleVerticalGrids.values {
+        for grid in columnHeaderView.visibleVerticalGridlines.values {
             grid.position.y += centerOffset.y
         }
-        for grid in tableView.visibleHorizontalGrids.values {
+        for grid in tableView.visibleHorizontalGridlines.values {
             grid.position.y += centerOffset.y
         }
-        for grid in tableView.visibleVerticalGrids.values {
+        for grid in tableView.visibleVerticalGridlines.values {
             grid.position.y += centerOffset.y
         }
     }
@@ -79,16 +79,16 @@ extension SpreadsheetView {
                 cell.center.x += cellOffset
             }
 
-            for grid in rowHeaderView.visibleHorizontalGrids.values {
+            for grid in rowHeaderView.visibleHorizontalGridlines.values {
                 grid.position.x += cellOffset
             }
-            for grid in rowHeaderView.visibleVerticalGrids.values {
+            for grid in rowHeaderView.visibleVerticalGridlines.values {
                 grid.position.x += cellOffset
             }
-            for grid in tableView.visibleHorizontalGrids.values {
+            for grid in tableView.visibleHorizontalGridlines.values {
                 grid.position.x += cellOffset
             }
-            for grid in tableView.visibleVerticalGrids.values {
+            for grid in tableView.visibleVerticalGridlines.values {
                 grid.position.x += cellOffset
             }
         }
@@ -114,16 +114,16 @@ extension SpreadsheetView {
                 cell.center.y += cellOffset
             }
 
-            for grid in columnHeaderView.visibleHorizontalGrids.values {
+            for grid in columnHeaderView.visibleHorizontalGridlines.values {
                 grid.position.y += cellOffset
             }
-            for grid in columnHeaderView.visibleVerticalGrids.values {
+            for grid in columnHeaderView.visibleVerticalGridlines.values {
                 grid.position.y += cellOffset
             }
-            for grid in tableView.visibleHorizontalGrids.values {
+            for grid in tableView.visibleHorizontalGridlines.values {
                 grid.position.y += cellOffset
             }
-            for grid in tableView.visibleVerticalGrids.values {
+            for grid in tableView.visibleVerticalGridlines.values {
                 grid.position.y += cellOffset
             }
         }


### PR DESCRIPTION
`Grids` and `Cell.grids` are deprecated. use `Gridlines` and `Cell.gridlines` instead.