### PR TITLE
Fix contentOffset and scrollIndicatorInsets should be public vars

### DIFF
--- a/Framework/Sources/SpreadsheetView+UIScrollView.swift
+++ b/Framework/Sources/SpreadsheetView+UIScrollView.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 extension SpreadsheetView {
-    var contentOffset: CGPoint {
+    public var contentOffset: CGPoint {
         get {
             return rootView.contentOffset
         }
@@ -18,7 +18,7 @@ extension SpreadsheetView {
         }
     }
 
-    var scrollIndicatorInsets: UIEdgeInsets {
+    public var scrollIndicatorInsets: UIEdgeInsets {
         get {
             return rootView.scrollIndicatorInsets
         }


### PR DESCRIPTION
First, thanks for this great project!

`contentOffset` and `scrollIndicatorInsets` should be public vars