### PR TITLE
Bump version to 0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,23 @@
 
 ##### Breaking
 
+* None.
+
+##### Enhancements
+
+* None.
+
+##### Bug Fixes
+
+* None.
+
+## 0.6.3 Release notes (2017-05-19)
+
+##### Breaking
+
 * Rename `Grids`/`Cell.grids` to `Gridlines`/`Cell.gridlines`. Old type and property are now deprecated.
   They will be removed in future version.   
-  [#13](https://github.com/kishikawakatsumi/SpreadsheetView/pull/13)
+  [#30](https://github.com/kishikawakatsumi/SpreadsheetView/pull/30)
 
 ##### Enhancements
 

--- a/Framework/Sources/Info.plist
+++ b/Framework/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.2</string>
+	<string>0.6.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/SpreadsheetView.podspec
+++ b/SpreadsheetView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SpreadsheetView'
-  s.version          = '0.6.2'
+  s.version          = '0.6.3'
   s.summary          = 'Full configurable spreadsheet view user interfaces for iOS applications.'
   s.description      = <<-DESC
                          Full configurable spreadsheet view user interfaces for iOS applications. With this framework, 


### PR DESCRIPTION
## 0.6.3 Release notes (2017-05-19)

##### Breaking

* Rename `Grids`/`Cell.grids` to `Gridlines`/`Cell.gridlines`. Old type and property are now deprecated.
  They will be removed in future version.   
  [#30](https://github.com/kishikawakatsumi/SpreadsheetView/pull/30)

##### Enhancements

* None.

##### Bug Fixes

* Fix a view on the cell cannot receive touch events.
  [#42](https://github.com/kishikawakatsumi/SpreadsheetView/pull/42)
* Fix an issue that `reloadData()` doesn't reflect the latest state correctly.
  [#37](https://github.com/kishikawakatsumi/SpreadsheetView/pull/37)