### PR TITLE
Updated SpreadsheedView to `open`

### DIFF
--- a/Framework/Sources/SpreadsheetView+Layout.swift
+++ b/Framework/Sources/SpreadsheetView+Layout.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 extension SpreadsheetView {
-    public override func layoutSubviews() {
+    open override func layoutSubviews() {
         super.layoutSubviews()
 
         tableView.delegate = nil

--- a/Framework/Sources/SpreadsheetView+UIScrollView.swift
+++ b/Framework/Sources/SpreadsheetView+UIScrollView.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 extension SpreadsheetView {
-    public override func isKind(of aClass: AnyClass) -> Bool {
+    override open func isKind(of aClass: AnyClass) -> Bool {
         return rootView.isKind(of: aClass)
     }
 

--- a/Framework/Sources/SpreadsheetView+UISnapshotting.swift
+++ b/Framework/Sources/SpreadsheetView+UISnapshotting.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 extension SpreadsheetView {
-    public override func resizableSnapshotView(from rect: CGRect, afterScreenUpdates afterUpdates: Bool, withCapInsets capInsets: UIEdgeInsets) -> UIView? {
+    open override func resizableSnapshotView(from rect: CGRect, afterScreenUpdates afterUpdates: Bool, withCapInsets capInsets: UIEdgeInsets) -> UIView? {
         if cornerView.frame.intersects(cornerView.convert(rect, to: self)) {
             return cornerView.resizableSnapshotView(from: rect.offsetBy(dx: -cornerView.frame.origin.x, dy: -cornerView.frame.origin.y),
                                                     afterScreenUpdates: afterUpdates,

--- a/Framework/Sources/SpreadsheetView+UIViewHierarchy.swift
+++ b/Framework/Sources/SpreadsheetView+UIViewHierarchy.swift
@@ -9,31 +9,31 @@
 import UIKit
 
 extension SpreadsheetView {
-    public override func insertSubview(_ view: UIView, at index: Int) {
+    open override func insertSubview(_ view: UIView, at index: Int) {
         overlayView.insertSubview(view, at: index)
     }
 
-    public override func exchangeSubview(at index1: Int, withSubviewAt index2: Int) {
+    open override func exchangeSubview(at index1: Int, withSubviewAt index2: Int) {
         overlayView.exchangeSubview(at: index1, withSubviewAt: index2)
     }
 
-    public override func addSubview(_ view: UIView) {
+    open override func addSubview(_ view: UIView) {
         overlayView.addSubview(view)
     }
 
-    public override func insertSubview(_ view: UIView, belowSubview siblingSubview: UIView) {
+    open override func insertSubview(_ view: UIView, belowSubview siblingSubview: UIView) {
         overlayView.insertSubview(view, belowSubview: siblingSubview)
     }
 
-    public override func insertSubview(_ view: UIView, aboveSubview siblingSubview: UIView) {
+    open override func insertSubview(_ view: UIView, aboveSubview siblingSubview: UIView) {
         overlayView.insertSubview(view, aboveSubview: siblingSubview)
     }
 
-    public override func bringSubview(toFront view: UIView) {
+    open override func bringSubview(toFront view: UIView) {
         overlayView.bringSubview(toFront: view)
     }
 
-    public override func sendSubview(toBack view: UIView) {
+    open override func sendSubview(toBack view: UIView) {
         overlayView.sendSubview(toBack: view)
     }
 }

--- a/Framework/Sources/SpreadsheetView.swift
+++ b/Framework/Sources/SpreadsheetView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public class SpreadsheetView: UIView {
+open class SpreadsheetView: UIView {
     /// The object that provides the data for the collection view.
     ///
     /// - Note: The data source must adopt the `SpreadsheetViewDataSource` protocol.


### PR DESCRIPTION
So that it can be subclassed outside it's module
Relates to issue #52