### PR TITLE
Update iOS simulator version to `10.3.1` for CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,11 @@ jobs:
   - <<: *test
     script:
     - bundle exec rake test-without-building:simulator
-      DESTINATION='name=iPhone 6s,OS=10.3'
+      DESTINATION='name=iPhone 6s,OS=10.3.1'
   - <<: *test
     script:
     - bundle exec rake test-without-building:simulator
-      DESTINATION='name=iPhone 7 Plus,OS=10.3'
+      DESTINATION='name=iPhone 7 Plus,OS=10.3.1'
   - <<: *test
     script:
     - bundle exec rake test-without-building:simulator
@@ -63,15 +63,15 @@ jobs:
   - <<: *test
     script:
     - bundle exec rake test-without-building:simulator
-      DESTINATION='name=iPad Air 2,OS=10.3'
+      DESTINATION='name=iPad Air 2,OS=10.3.1'
   - <<: *test
     script:
     - bundle exec rake test-without-building:simulator
-      DESTINATION='name=iPad Pro (9.7-inch),OS=10.3'
+      DESTINATION='name=iPad Pro (9.7-inch),OS=10.3.1'
   - <<: *test
     script:
     - bundle exec rake test-without-building:simulator
-      DESTINATION='name=iPad Pro (12.9-inch),OS=10.3'
+      DESTINATION='name=iPad Pro (12.9-inch),OS=10.3.1'
   - stage: carthage
     install:
     - brew update


### PR DESCRIPTION
Travis CI seems to update existing Xcode 8.3 environment.