### PR TITLE
Adds stickyHeader options

### DIFF
--- a/Framework/Sources/SpreadsheetView+Layout.swift
+++ b/Framework/Sources/SpreadsheetView+Layout.swift
@@ -35,17 +35,6 @@ extension SpreadsheetView {
         layoutRowHeader()
         layoutColumnHeader()
 
-        if self.stickyRowHeader {
-            self.rowHeaderView.frame.origin.y = min(self.rootView.contentOffset.y, 0)
-            self.rowHeaderView.contentOffset.x = self.tableView.contentOffset.x
-            self.cornerView.frame.origin.y = min(self.rootView.contentOffset.y, 0)
-        }
-        if self.stickyColumnHeader {
-            self.columnHeaderView.frame.origin.x = min(self.rootView.contentOffset.x, 0)
-            self.columnHeaderView.contentOffset.y = self.tableView.contentOffset.y
-            self.cornerView.frame.origin.x = min(self.rootView.contentOffset.x, 0)
-        }
-        
         if needsReload {
             adjustScrollViewFrames()
 

--- a/Framework/Sources/SpreadsheetView+Layout.swift
+++ b/Framework/Sources/SpreadsheetView+Layout.swift
@@ -35,6 +35,17 @@ extension SpreadsheetView {
         layoutRowHeader()
         layoutColumnHeader()
 
+        if self.stickyRowHeader {
+            self.rowHeaderView.frame.origin.y = min(self.rootView.contentOffset.y, 0)
+            self.rowHeaderView.contentOffset.x = self.tableView.contentOffset.x
+            self.cornerView.frame.origin.y = min(self.rootView.contentOffset.y, 0)
+        }
+        if self.stickyColumnHeader {
+            self.columnHeaderView.frame.origin.x = min(self.rootView.contentOffset.x, 0)
+            self.columnHeaderView.contentOffset.y = self.tableView.contentOffset.y
+            self.cornerView.frame.origin.x = min(self.rootView.contentOffset.x, 0)
+        }
+        
         if needsReload {
             adjustScrollViewFrames()
 

--- a/Framework/Sources/SpreadsheetView+UIScrollViewDelegate.swift
+++ b/Framework/Sources/SpreadsheetView+UIScrollViewDelegate.swift
@@ -19,7 +19,7 @@ extension SpreadsheetView: UIScrollViewDelegate {
             tableView.delegate = self
         }
 
-        if tableView.contentOffset.x < 0 {
+        if tableView.contentOffset.x < 0 && !stickyColumnHeader {
             let offset = tableView.contentOffset.x * -1
             cornerView.frame.origin.x = offset
             columnHeaderView.frame.origin.x = offset
@@ -27,7 +27,7 @@ extension SpreadsheetView: UIScrollViewDelegate {
             cornerView.frame.origin.x = 0
             columnHeaderView.frame.origin.x = 0
         }
-        if tableView.contentOffset.y < 0 {
+        if tableView.contentOffset.y < 0 && !stickyRowHeader {
             let offset = tableView.contentOffset.y * -1
             cornerView.frame.origin.y = offset
             rowHeaderView.frame.origin.y = offset

--- a/Framework/Sources/SpreadsheetView.swift
+++ b/Framework/Sources/SpreadsheetView.swift
@@ -219,6 +219,20 @@ public class SpreadsheetView: UIView {
             tableView.alwaysBounceHorizontal = newValue
         }
     }
+    
+    /// A Boolean value that determines wheather the row header always sticks to the top.
+    /// - Note: `bounces` has to be `true` and there has to be at least one `frozenRow`.
+    /// The default value is `false`.
+    ///
+    /// - SeeAlso: `stickyColumnHeader`
+    public var stickyRowHeader: Bool = false
+    
+    /// A Boolean value that determines wheather the column header always sticks to the top.
+    /// - Note: `bounces` has to be `true` and there has to be at least one `frozenColumn`.
+    /// The default value is `false`.
+    ///
+    /// - SeeAlso: `stickyRowHeader`
+    public var stickyColumnHeader: Bool = false
 
     /// A Boolean value that determines whether paging is enabled for the scroll view.
     /// - Note: If the value of this property is `true`, the scroll view stops on multiples of the scroll view’s bounds when the user scrolls.


### PR DESCRIPTION
## The problem:
I wanted the header always to stick to the top of the screen, even if the table "bounces" beyond `contentOffset` >= 0. 
## My solution:
I introduced to new properties to `SpreadsheetView`: `stickyRowHeader` and `stickyColumnHeader`.
They both default to `false`.
If set to `true` the respective header will always stick to the top/left.

I don't know the layout code enough to know if my layout change is very elegant. Maybe someone more knowledgeable could comment on that and suggest different points to do the layout.

### Example with both properties `true`:
![simulator screen shot 6 jul 2017 17 59 40](https://user-images.githubusercontent.com/9119485/27920463-ecd21de0-6274-11e7-820e-0f3fc6f826d6.png)