### PR TITLE
Fixed an issue where the `scrollToItem (at: at: animated:)` method caused the view to scroll beyond the scrollable area.

### DIFF
--- a/Framework/Sources/SpreadsheetView.swift
+++ b/Framework/Sources/SpreadsheetView.swift
@@ -576,6 +576,13 @@ public class SpreadsheetView: UIView {
             fatalError("attempt to use a scroll position with multiple vertical positioning styles")
         }
 
+        if contentOffset.x < 0 {
+            contentOffset.x = 0
+        }
+        if contentOffset.y < 0 {
+            contentOffset.y = 0
+        }
+
         return contentOffset
     }
 


### PR DESCRIPTION
Fixes https://github.com/kishikawakatsumi/SpreadsheetView/issues/81