### PR TITLE
Reflect the content size from the model to the view when reloading.

### DIFF
--- a/Framework/Sources/SpreadsheetView+Layout.swift
+++ b/Framework/Sources/SpreadsheetView+Layout.swift
@@ -241,6 +241,10 @@ extension SpreadsheetView {
     }
 
     func resetContentSize(of scrollView: ScrollView) {
+        defer {
+            scrollView.contentSize = scrollView.state.contentSize
+        }
+
         scrollView.columnRecords.removeAll()
         scrollView.rowRecords.removeAll()
 


### PR DESCRIPTION
Fixed an issue where the content size may be incorrect after reloading. This is a regression in `v0.8.1`.

Fixes #125 