### PR TITLE
Adds functions from UIScrollView's delegate to SpreadsheetViewDelegate

### DIFF
--- a/Examples/ClassData/Sources/ViewController.swift
+++ b/Examples/ClassData/Sources/ViewController.swift
@@ -112,4 +112,18 @@ class ViewController: UIViewController, SpreadsheetViewDataSource, SpreadsheetVi
             spreadsheetView.reloadData()
         }
     }
+    
+    
+    public func scrollViewWillBeginDragging(_ spreadsheetView: SpreadsheetView, scrollView: UIScrollView) {
+        print("WillBeginDragging")
+    }
+    
+    public func scrollViewWillEndDragging(_ spreadsheetView: SpreadsheetView, scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+        print("WillEndDragging")
+    }
+    
+    public func scrollViewDidScroll(_ spreadsheetView: SpreadsheetView, scrollView: UIScrollView) {
+        print("DidScroll")
+    }
+    
 }

--- a/Framework/Sources/SpreadsheetView+UIScrollViewDelegate.swift
+++ b/Framework/Sources/SpreadsheetView+UIScrollViewDelegate.swift
@@ -9,7 +9,29 @@
 import UIKit
 
 extension SpreadsheetView: UIScrollViewDelegate {
+    
+    public func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        
+        if scrollView == tableView {
+            delegate?.scrollViewWillBeginDragging(self, scrollView: scrollView)
+        }
+        
+    }
+    
+    public func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+        
+        if scrollView == tableView {
+            delegate?.scrollViewWillEndDragging(self, scrollView: scrollView, withVelocity: velocity, targetContentOffset: targetContentOffset)
+        }
+        
+    }
+    
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        
+        if scrollView == tableView {
+            delegate?.scrollViewDidScroll(self, scrollView: scrollView)
+        }
+        
         rowHeaderView.delegate = nil
         columnHeaderView.delegate = nil
         tableView.delegate = nil

--- a/Framework/Sources/SpreadsheetViewDelegate.swift
+++ b/Framework/Sources/SpreadsheetViewDelegate.swift
@@ -80,6 +80,22 @@ public protocol SpreadsheetViewDelegate: class {
     ///   - spreadsheetView: The spreadsheet view object that is notifying you of the selection change.
     ///   - indexPath: The index path of the cell that was deselected.
     func spreadsheetView(_ spreadsheetView: SpreadsheetView, didDeselectItemAt indexPath: IndexPath)
+    
+    /// 1:1 Mapping of the underlying UIScrollView delegate
+    /// scrollViewWillBeginDragging(_ scrollView: UIScrollView)
+    /// for UIScrollView 'tableView'.
+    func scrollViewWillBeginDragging(_ spreadsheetView: SpreadsheetView, scrollView: UIScrollView)
+
+    /// 1:1 Mapping of the underlying UIScrollView delegate
+    /// scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>)
+    /// for UIScrollView 'tableView'.
+    func scrollViewWillEndDragging(_ spreadsheetView: SpreadsheetView, scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>)
+    
+    /// 1:1 Mapping of the underlying UIScrollView delegate
+    /// scrollViewDidScroll(_ scrollView: UIScrollView)
+    /// for UIScrollView 'tableView'.
+    func scrollViewDidScroll(_ spreadsheetView: SpreadsheetView, scrollView: UIScrollView)
+
 }
 
 extension SpreadsheetViewDelegate {
@@ -90,4 +106,8 @@ extension SpreadsheetViewDelegate {
     public func spreadsheetView(_ spreadsheetView: SpreadsheetView, shouldDeselectItemAt indexPath: IndexPath) -> Bool { return true }
     public func spreadsheetView(_ spreadsheetView: SpreadsheetView, didSelectItemAt indexPath: IndexPath) {}
     public func spreadsheetView(_ spreadsheetView: SpreadsheetView, didDeselectItemAt indexPath: IndexPath) {}
+    
+    public func scrollViewWillBeginDragging(_ spreadsheetView: SpreadsheetView, scrollView: UIScrollView) {}
+    public func scrollViewWillEndDragging(_ spreadsheetView: SpreadsheetView, scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {}
+    public func scrollViewDidScroll(_ spreadsheetView: SpreadsheetView, scrollView: UIScrollView) {}
 }


### PR DESCRIPTION
Hi,

first of all: Great Framework, really works well for our use case: We need to display a huge mapping table and must allow the user quick access to all fields.

I added some delegate callbacks from the underlying the UIScrollView in the SpreadsheetView, so we could detect the start and end of the user's interaction with the view. I'm not sure if this isn't already possible using you're Framework as it is. Furthermore we only used the underlying tableView as an indicator for actual interactions on the UIScrollView of the SpreadsheetView - I'm not sure if this is the right move - at least in our examples it works perfect.


+ Adds mapping for UIScrollView delegate function scrollViewWillBeginDragging
+ Adds mapping for UIScrollView delegate function scrollViewWillEndDragging
+ Adds mapping for UIScrollView delegate function scrollViewDidScroll