### PR TITLE
Fix touches not work after first touch be canceled

### DIFF
--- a/Framework/Sources/SpreadsheetView+Touches.swift
+++ b/Framework/Sources/SpreadsheetView+Touches.swift
@@ -49,7 +49,7 @@ extension SpreadsheetView {
     func touchesCancelled(_ touches: Set<UITouch>, _ event: UIEvent?) {
         unhighlightAllItems()
         restorePreviousSelection()
-        restorePreviousSelection()
+        clearCurrentTouch()
     }
 
     func highlightItems(on touches: Set<UITouch>) {


### PR DESCRIPTION
Seems a wrong method call after this change: https://github.com/Golface/SpreadsheetView/commit/dff8da74377572fae16008f96d34e8e56d14b745

May fix this [issue]( https://github.com/bannzai/SpreadsheetView/issues/264).